### PR TITLE
Issue #236: Added GenericChannelUserOutput Interface for methods action, message and notice

### DIFF
--- a/src/main/java/org/pircbotx/output/GenericChannelUserOutput.java
+++ b/src/main/java/org/pircbotx/output/GenericChannelUserOutput.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2010-2014 Leon Blakey <lord.quackstar at gmail.com>
+ *
+ * This file is part of PircBotX.
+ *
+ * PircBotX is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * PircBotX is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * PircBotX. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.pircbotx.output;
+
+/**
+ * Interface for sending lines to the represented user or channel.
+ *
+ * @author Finn Glöe
+ */
+public interface GenericChannelUserOutput {
+	/**
+	 * Send an action to the represented user or channel.
+	 * 
+	 * @param action
+	 */
+	public void action(String action);
+	
+	/**
+	 * Send a message to the represented user or channel.
+	 * 
+	 * @param message
+	 */
+	public void message(String message);
+	
+	/**
+	 * Send a notice to the represented user or channel.
+	 * 
+	 * @param notice
+	 */
+	public void notice(String notice);
+}

--- a/src/main/java/org/pircbotx/output/OutputChannel.java
+++ b/src/main/java/org/pircbotx/output/OutputChannel.java
@@ -32,7 +32,7 @@ import org.pircbotx.hooks.events.PartEvent;
  * @author Leon Blakey
  */
 @RequiredArgsConstructor
-public class OutputChannel {
+public class OutputChannel implements GenericChannelUserOutput {
 	@NonNull
 	protected final PircBotX bot;
 	@NonNull

--- a/src/main/java/org/pircbotx/output/OutputUser.java
+++ b/src/main/java/org/pircbotx/output/OutputUser.java
@@ -34,7 +34,7 @@ import org.pircbotx.exception.DccException;
  * @author Leon Blakey
  */
 @RequiredArgsConstructor
-public class OutputUser {
+public class OutputUser implements GenericChannelUserOutput {
 	@NonNull
 	protected final PircBotX bot;
 	@NonNull

--- a/src/test/java/org/pircbotx/output/OutputTest.java
+++ b/src/test/java/org/pircbotx/output/OutputTest.java
@@ -243,6 +243,48 @@ public class OutputTest {
 		bot.sendIRC().notice("aUser", aString);
 		checkOutput("NOTICE aUser :" + aString);
 	}
+	
+	@Test(description = "Verify sendAction to channel through generic Interface")
+	public void sendActionChannelInterfaceTest() throws Exception {
+		GenericChannelUserOutput out = aChannel.send();
+		out.action(aString);
+		checkOutput("PRIVMSG #aChannel :\u0001ACTION " + aString + "\u0001");
+	}
+	
+	@Test(description = "Verify sendAction to user through generic Interface")
+	public void sendActionUserInterfaceTest() throws Exception {
+		GenericChannelUserOutput out = aUser.send();
+		out.action(aString);
+		checkOutput("PRIVMSG SourceUser :\u0001ACTION " + aString + "\u0001");
+	}
+	
+	@Test(description = "Verify sendMessage to channel through generic Interface")
+	public void sendMessageChannelInterfaceTest() throws Exception {
+		GenericChannelUserOutput out = aChannel.send();
+		out.message(aString);
+		checkOutput("PRIVMSG #aChannel :" + aString);
+	}
+	
+	@Test(description = "Verify sendMessage to user through generic Interface")
+	public void sendMessageUserInterfaceTest() throws Exception {
+		GenericChannelUserOutput out = aUser.send();
+		out.message(aString);
+		checkOutput("PRIVMSG SourceUser :" + aString);
+	}
+	
+	@Test(description = "Verify sendNotice to channel through generic Interface")
+	public void sendNoticeChannelInterfaceTest() throws Exception {
+		GenericChannelUserOutput out = aChannel.send();
+		out.notice(aString);
+		checkOutput("NOTICE #aChannel :" + aString);
+	}
+	
+	@Test(description = "Verify sendNotice to user through generic Interface")
+	public void sendNoticeUserInterfaceTest() throws Exception {
+		GenericChannelUserOutput out = aUser.send();
+		out.notice(aString);
+		checkOutput("NOTICE SourceUser :" + aString);
+	}
 
 	@Test
 	public void sendQuit() throws Exception {


### PR DESCRIPTION
This PR solves Issue #236. It allows you to access The output of a channel or user in the same way by using GenericChannelUserOutput.

    GenericChannelUserOutput out = null;
    if(event instanceof MessageEvent) {
    	out = ((MessageEvent) event).getChannel().send();
    } else {
    	out = event.getUser().send();
    }
    out.message("This is a simple message!");